### PR TITLE
Some minor changes related to the config manager

### DIFF
--- a/src/main/java/org/icatproject/authn_oidc/OIDC_Authenticator.java
+++ b/src/main/java/org/icatproject/authn_oidc/OIDC_Authenticator.java
@@ -120,12 +120,10 @@ public class OIDC_Authenticator {
 		configurationManager.exit();
 	}
 
-	@GET
+	@POST
 	@Path("jwkupdate")
-	@Produces(MediaType.TEXT_PLAIN)
-	public String jwkUpdate() {
+	public void jwkUpdate() {
 		configurationManager.checkJwkProvider();
-		return "JWK update successful";
 	}
 
 	@GET

--- a/src/main/java/org/icatproject/authn_oidc/OpenidConfigurationManager.java
+++ b/src/main/java/org/icatproject/authn_oidc/OpenidConfigurationManager.java
@@ -106,7 +106,7 @@ public class OpenidConfigurationManager {
         }
 
         jwkProvider = provider;
-	logger.info("jwkProvider updated successfully");
+        logger.info("jwkProvider updated successfully");
     }
 
 }

--- a/src/main/java/org/icatproject/authn_oidc/OpenidConfigurationManager.java
+++ b/src/main/java/org/icatproject/authn_oidc/OpenidConfigurationManager.java
@@ -106,6 +106,7 @@ public class OpenidConfigurationManager {
         }
 
         jwkProvider = provider;
+	logger.info("jwkProvider updated successfully");
     }
 
 }

--- a/src/main/java/org/icatproject/authn_oidc/OpenidConfigurationManager.java
+++ b/src/main/java/org/icatproject/authn_oidc/OpenidConfigurationManager.java
@@ -48,7 +48,7 @@ public class OpenidConfigurationManager {
 
     private URL openidConfigurationUrl;
     private String tokenIssuer;
-    private JwkProvider jwkProvider;
+    private JwkProvider jwkProvider = null;
 
     private Timer timer = new Timer();
 
@@ -72,8 +72,6 @@ public class OpenidConfigurationManager {
     }
 
     public void checkJwkProvider() {
-        jwkProvider = null;
-
         JsonObject jsonResponse;
         try {
             HttpURLConnection con = (HttpURLConnection) openidConfigurationUrl.openConnection();

--- a/src/main/java/org/icatproject/authn_oidc/OpenidConfigurationManager.java
+++ b/src/main/java/org/icatproject/authn_oidc/OpenidConfigurationManager.java
@@ -23,90 +23,90 @@ import org.slf4j.LoggerFactory;
 
 public class OpenidConfigurationManager {
 
-    public class Action extends TimerTask {
+	public class Action extends TimerTask {
 
-        @Override
-        public void run() {
-            Thread.currentThread().setPriority(Thread.MAX_PRIORITY);
-            jwkUpdate();
-        }
-    }
+		@Override
+		public void run() {
+			Thread.currentThread().setPriority(Thread.MAX_PRIORITY);
+			jwkUpdate();
+		}
+	}
 
-    private void jwkUpdate() {
-        long intervalMillis = 86400000L; // 24 hours
-        try {
-            checkJwkProvider();
-        } catch (RuntimeException e) {
-            logger.error(e.getMessage());
-            intervalMillis = 60000L; // 1 minute
-        } finally {
-            timer.schedule(new Action(), intervalMillis);
-        }
-    }
+	private void jwkUpdate() {
+		long intervalMillis = 86400000L; // 24 hours
+		try {
+			checkJwkProvider();
+		} catch (RuntimeException e) {
+			logger.error(e.getMessage());
+			intervalMillis = 60000L; // 1 minute
+		} finally {
+			timer.schedule(new Action(), intervalMillis);
+		}
+	}
 
-    private static final Logger logger = LoggerFactory.getLogger(OpenidConfigurationManager.class);
+	private static final Logger logger = LoggerFactory.getLogger(OpenidConfigurationManager.class);
 
-    private URL openidConfigurationUrl;
-    private String tokenIssuer;
-    private JwkProvider jwkProvider = null;
+	private URL openidConfigurationUrl;
+	private String tokenIssuer;
+	private JwkProvider jwkProvider = null;
 
-    private Timer timer = new Timer();
+	private Timer timer = new Timer();
 
-    public OpenidConfigurationManager(String wellKnownUrl, String issuer) throws MalformedURLException {
-        openidConfigurationUrl = new URL(wellKnownUrl);
-        tokenIssuer = issuer;
+	public OpenidConfigurationManager(String wellKnownUrl, String issuer) throws MalformedURLException {
+		openidConfigurationUrl = new URL(wellKnownUrl);
+		tokenIssuer = issuer;
 
-        jwkUpdate();
-    }
+		jwkUpdate();
+	}
 
-    public void exit() {
-        timer.cancel();
-    }
+	public void exit() {
+		timer.cancel();
+	}
 
-    public String getTokenIssuer() {
-        return tokenIssuer;
-    }
+	public String getTokenIssuer() {
+		return tokenIssuer;
+	}
 
-    public JwkProvider getJwkProvider() {
-        return jwkProvider;
-    }
+	public JwkProvider getJwkProvider() {
+		return jwkProvider;
+	}
 
-    public void checkJwkProvider() {
-        JsonObject jsonResponse;
-        try {
-            HttpURLConnection con = (HttpURLConnection) openidConfigurationUrl.openConnection();
-            BufferedReader in = new BufferedReader(new InputStreamReader(con.getInputStream()));
-            StringBuffer response = new StringBuffer();
-            String inputLine;
-            while ((inputLine = in.readLine()) != null) {
-                response.append(inputLine);
-            }
-            in.close();
-            JsonReader jsonReader = Json.createReader(new StringReader(response.toString()));
-            jsonResponse = jsonReader.readObject();
-        } catch (IOException | JsonException e) {
-            String msg = "Unable to obtain information from the wellKnownUrl in run.properties: " + e.getMessage();
-            throw new RuntimeException(msg);
-        }
+	public void checkJwkProvider() {
+		JsonObject jsonResponse;
+		try {
+			HttpURLConnection con = (HttpURLConnection) openidConfigurationUrl.openConnection();
+			BufferedReader in = new BufferedReader(new InputStreamReader(con.getInputStream()));
+			StringBuffer response = new StringBuffer();
+			String inputLine;
+			while ((inputLine = in.readLine()) != null) {
+				response.append(inputLine);
+			}
+			in.close();
+			JsonReader jsonReader = Json.createReader(new StringReader(response.toString()));
+			jsonResponse = jsonReader.readObject();
+		} catch (IOException | JsonException e) {
+			String msg = "Unable to obtain information from the wellKnownUrl in run.properties: " + e.getMessage();
+			throw new RuntimeException(msg);
+		}
 
-        JwkProvider provider;
-        String issuer;
-        try {
-            String jwksUrl = jsonResponse.getString("jwks_uri");
-            provider = new JwkProviderBuilder(new URL(jwksUrl)).build();
-            issuer = jsonResponse.getString("issuer");
-        } catch (NullPointerException | MalformedURLException e) {
-            String msg = "Unable to obtain JWK provider or issuer: " + e.getMessage();
-            throw new RuntimeException(msg);
-        }
+		JwkProvider provider;
+		String issuer;
+		try {
+			String jwksUrl = jsonResponse.getString("jwks_uri");
+			provider = new JwkProviderBuilder(new URL(jwksUrl)).build();
+			issuer = jsonResponse.getString("issuer");
+		} catch (NullPointerException | MalformedURLException e) {
+			String msg = "Unable to obtain JWK provider or issuer: " + e.getMessage();
+			throw new RuntimeException(msg);
+		}
 
-        if (!tokenIssuer.equals(issuer)) {
-            String msg = "The issuer in the well-known configuration does not match the tokenIssuer in run.properties.";
-            throw new RuntimeException(msg);
-        }
+		if (!tokenIssuer.equals(issuer)) {
+			String msg = "The issuer in the well-known configuration does not match the tokenIssuer in run.properties.";
+			throw new RuntimeException(msg);
+		}
 
-        jwkProvider = provider;
-        logger.info("jwkProvider updated successfully");
-    }
+		jwkProvider = provider;
+		logger.info("jwkProvider updated successfully");
+	}
 
 }

--- a/src/site/xhtml/installation.xhtml.vm
+++ b/src/site/xhtml/installation.xhtml.vm
@@ -162,7 +162,7 @@
 			which returns a description, <br />
 			<code>curl -k https://localhost:8181/authn.oidc/version -w "\n"</code>
 			which returns the version, <br />
-			<code>curl -k https://localhost:8181/authn.oidc/jwkupdate -w "\n"</code>
+			<code>curl -k https://localhost:8181/authn.oidc/jwkupdate -X POST</code>
 			which triggers an update of the JWK configuration, and <br />
 			<code>curl -k https://localhost:8181/authn.oidc/authenticate -w "\n"
 			-d 'json={"credentials":[{"token":"&lt;token&gt;"}]}'</code>


### PR DESCRIPTION
- If the update of the `jwkProvider` fails, continue to use the old one rather then resetting it to `null`.
- Change the `jwkupdate` call from `GET` to `POST`.  According to common standards, HTTP `GET` should not have any side effects.
- Do not return a success message in the `jwkupdate` call.  This is redundant with the HTTP status code.
- Add a log message on successfully updating the `jwkProvider`.  It may be useful to have a record in the log when it was updated last time.