### PR TITLE
Bump dependency on icat.utils to 4.16.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
 		<dependency>
 			<groupId>org.icatproject</groupId>
 			<artifactId>icat.utils</artifactId>
-			<version>4.16.0</version>
+			<version>4.16.1</version>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
Bump the dependency on icat.utils to 4.16.1 (released on 2021-02-11). This adds Python 3 compatibility for the setup script.