### PR TITLE
Add a 'requiredScope' config option to restrict login

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
 	<groupId>org.icatproject</groupId>
 	<artifactId>authn.oidc</artifactId>
-	<version>1.0.1-SNAPSHOT</version>
+	<version>1.1.0-SNAPSHOT</version>
 	<packaging>war</packaging>
 	<name>ICAT: authn.oidc</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -8,10 +8,10 @@
 	<name>ICAT: authn.oidc</name>
 
 	<description>
-      This is the OIDC Authentication plugin for ICAT.  It is based on the
-      OpenID Connect protocol and works by verifying tokens issued by an external
-      Identity Provider.
-    </description>
+		This is the OIDC Authentication plugin for ICAT.  It is based on the
+		OpenID Connect protocol and works by verifying tokens issued by an external
+		Identity Provider.
+	</description>
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -24,7 +24,7 @@
 	<repositories>
 		<repository>
 			<id>ICAT Repo</id>
-			<url>http://www.icatproject.org/mvn/repo</url>
+			<url>${repoUrl}</url>
 		</repository>
 	</repositories>
 

--- a/src/main/config/run.properties.example
+++ b/src/main/config/run.properties.example
@@ -14,6 +14,10 @@ icatUserClaim = icatUser
 # Otherwise, authn.oidc falls back to using the 'sub' claim.
 !icatUserClaimException = true
 
+# Require the token to have a particular scope. If specified, tokens without
+# this scope will be rejected.
+!requiredScope = icat_login
+
 # If access to the OIDC authentication should only be allowed from certain
 # IP addresses then provide a space separated list of allowed values. These
 # take the form of an IPV4 or IPV6 address followed by the number of bits

--- a/src/main/java/org/icatproject/authn_oidc/OIDC_Authenticator.java
+++ b/src/main/java/org/icatproject/authn_oidc/OIDC_Authenticator.java
@@ -202,6 +202,15 @@ public class OIDC_Authenticator {
 			}
 		}
 
+		Claim iss = decodedJWT.getClaim("iss");
+		if (iss.isNull()) {
+			throw new AuthnException(HttpURLConnection.HTTP_FORBIDDEN, "The token is missing the iss claim");
+		}
+		if (!configurationManager.getTokenIssuer().equals(iss.asString())) {
+			throw new AuthnException(HttpURLConnection.HTTP_FORBIDDEN,
+					"The iss claim of the token does not match the configured issuer");
+		}
+
 		String kid = decodedJWT.getKeyId();
 		if (kid == null) {
 			throw new AuthnException(HttpURLConnection.HTTP_FORBIDDEN, "The token is missing a kid");
@@ -225,15 +234,6 @@ public class OIDC_Authenticator {
 			throw new AuthnException(HttpURLConnection.HTTP_FORBIDDEN, "The token has expired");
 		} catch (JWTVerificationException | JwkException e) {
 			throw new AuthnException(HttpURLConnection.HTTP_FORBIDDEN, "The token is invalid");
-		}
-
-		Claim iss = decodedJWT.getClaim("iss");
-		if (iss.isNull()) {
-			throw new AuthnException(HttpURLConnection.HTTP_FORBIDDEN, "The token is missing the iss claim");
-		}
-		if (!configurationManager.getTokenIssuer().equals(iss.asString())) {
-			throw new AuthnException(HttpURLConnection.HTTP_FORBIDDEN,
-					"The iss claim of the token does not match the configured issuer");
 		}
 
 		String icatUser;

--- a/src/site/xhtml/installation.xhtml.vm
+++ b/src/site/xhtml/installation.xhtml.vm
@@ -110,10 +110,16 @@
 		</dd>
 		<dt>icatUserClaimException</dt>
 		<dd>
-			By default, if no icatUserClaim is present in the token, authn.oidc
-			falls back to using the 'sub' claim. If you would prefer an
-			AuthnException to be thrown in this case, set this property to
-			'true'.
+			By default, if no <code>icatUserClaim</code> is present in the
+			token, authn.oidc falls back to using the 'sub' claim. If you would
+			prefer an AuthnException to be thrown in this case, set this
+			property to 'true'.
+		</dd>
+		<dt>requiredScope</dt>
+		<dd>
+			If you only want to allow tokens with a particular scope, you can
+			specify it here. In this case, if a user tries to log in with a
+			token that doesn't have this scope, an AuthnException gets thrown.
 		</dd>
 		<dt>ip</dt>
 		<dd>

--- a/src/site/xhtml/release-notes.xhtml
+++ b/src/site/xhtml/release-notes.xhtml
@@ -6,6 +6,12 @@
 
 	<h1>Release Notes</h1>
 
+	<h2>1.1.0 (not yet released)</h2>
+	<p>Resctrict login via token scope.</p>
+	<ul>
+		<li>Add a 'requiredScope' config option to restrict login.</li>
+	</ul>
+
 	<h2>1.0.0</h2>
 	<p>
 		Initial release.


### PR DESCRIPTION
This adds a new (optional) `requiredScope` configuration option that can be used to only allow tokens with a particular scope.

If this configuration option is set, tokens without the specified scope get rejected by `authn.oidc`.