### PR TITLE
Use python3 instead of python

### DIFF
--- a/src/main/scripts/setup
+++ b/src/main/scripts/setup
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 from setup_utils import *
 import os
 

--- a/src/site/xhtml/release-notes.xhtml
+++ b/src/site/xhtml/release-notes.xhtml
@@ -10,6 +10,7 @@
 	<p>Resctrict login via token scope.</p>
 	<ul>
 		<li>#3: Add a 'requiredScope' config option to restrict login.</li>
+		<li>#5: Use python3 in the setup script.</li>
 		<li>#4: Bump dependency on logback-classic to version 1.2.0.</li>
 	</ul>
 


### PR DESCRIPTION
Modern distros often don't have a `python` command, so use `python3` explicitly.