### PR TITLE
Add CI using GitHub Actions

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -23,6 +23,14 @@ jobs:
           python-version: "3.9.7"
           architecture: x64
 
+      - name: Cache local Maven repository
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
       # ICAT Ansible clone and install dependencies
       - name: Checkout icat-ansible
         uses: actions/checkout@v2

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -3,6 +3,8 @@ on:
   workflow_dispatch:
   pull_request:
   push:
+    branches:
+      - master
 
 jobs:
   build_and_tests:

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -1,0 +1,82 @@
+name: CI Build
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+
+jobs:
+  build_and_tests:
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        java: [ '8', '11' ]
+    steps:
+      # Setup Java & Python
+      - name: Setup Java
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'temurin'
+          java-version: ${{ matrix.java }}
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.9.7"
+          architecture: x64
+
+      # ICAT Ansible clone and install dependencies
+      - name: Checkout icat-ansible
+        uses: actions/checkout@v2
+        with:
+          repository: icatproject-contrib/icat-ansible
+          path: icat-ansible
+          ref: master
+      - name: Install Ansible
+        run: pip install -r icat-ansible/requirements.txt
+
+      # Prep for running the playbook
+      - name: Create Hosts File
+        run: echo -e "[icatdb_minimal_hosts]\nlocalhost ansible_connection=local" > icat-ansible/hosts
+      - name: Prepare vault pass
+        run: echo -e "icattravispw" > icat-ansible/vault_pass.txt
+      - name: Move vault to directory it'll get detected by Ansible
+        run: mv icat-ansible/vault.yml icat-ansible/group_vars/all
+      - name: Replace default payara user with Actions user
+        run: |
+          sed -i -e "s/^payara_user: \"glassfish\"/payara_user: \"runner\"/" icat-ansible/group_vars/all/vars.yml
+      - name: Add Ansible Role
+        run: |
+          sed -i "/- role: icat_server$/a\
+          \    - role: dev_common" icat-ansible/icatdb_minimal_hosts.yml
+
+      # Force hostname to localhost - bug fix for previous ICAT Ansible issues on Actions
+      - name: Change hostname to localhost
+        run: sudo hostname -b localhost
+
+      # Remove existing MySQL installation so it doesn't interfere with GitHub Actions
+      - name: Remove existing mysql
+        run: |
+          sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
+          sudo apt-get remove --purge "mysql*"
+          sudo rm -rf /var/lib/mysql* /etc/mysql
+
+      # Create local instance of ICAT
+      - name: Run ICAT Ansible Playbook
+        run: |
+          ansible-playbook icat-ansible/icatdb_minimal_hosts.yml -i icat-ansible/hosts --vault-password-file icat-ansible/vault_pass.txt -vv
+
+      - name: Checkout authn-oidc
+        uses: actions/checkout@v2
+
+      # Payara must be sourced otherwise the Maven build command fails
+      - name: Run Build
+        run: |
+          grep payara ~/.bash_profile > payara_path_command
+          source payara_path_command
+          mvn install -DskipTests
+
+      - name: After Failure
+        if: ${{ failure() }}
+        run: |
+          cat /home/runner/logs/authn_oidc.log
+          cat /home/runner/logs/icat.log
+          cat /home/runner/payara*/glassfish/domains/domain1/logs/server.log

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -74,6 +74,9 @@ jobs:
           source payara_path_command
           mvn install -DskipTests
 
+      - name: Run Unit Tests
+        run: mvn test -B
+
       - name: After Failure
         if: ${{ failure() }}
         run: |

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # authn_oidc
 
+[![Build Status](https://github.com/icatproject/authn.oidc/workflows/CI%20Build/badge.svg?branch=master)](https://github.com/icatproject/authn.oidc/actions?query=workflow%3A%22CI+Build%22)
+
 General installation instructions are at http://www.icatproject.org/installation/component
 
 Specific installation instructions are at http://www.icatproject.org/mvn/site/authn/oidc/${project.version}/installation.html


### PR DESCRIPTION
Adds CI using GitHub Actions and a status badge to the README. The status badge will start working once this PR gets merged into `master`, but this is the status badge for this branch to prove that it works:

[![Build Status](https://github.com/icatproject/authn.oidc/workflows/CI%20Build/badge.svg?branch=add-ci)](https://github.com/icatproject/authn.oidc/actions?query=workflow%3A%22CI+Build%22)

- [ ] Should run maven build
- [ ] Should run unit tests
- [ ] Java 8 CI should pass
- [ ] Java 11 CI should pass