### PR TITLE
Switch to master branch of icat-ansible

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           repository: icatproject-contrib/icat-ansible
           path: icat-ansible
-          ref: payara6
+          ref: master
       - name: Install Ansible
         run: pip install -r icat-ansible/requirements.txt
 


### PR DESCRIPTION
Switch to master branch of icat-ansible in the ci-build workflow.  The payara6 branch seem to be outdated.
